### PR TITLE
Display default values

### DIFF
--- a/R/internal_functions.R
+++ b/R/internal_functions.R
@@ -77,8 +77,22 @@ create_tweedie <- function(mu, n, ancillary) {
 #' A function factory
 # Function to return a function that makes data perfect for glm model.
 make_simulating_function <- function(validLinks, defaultLink, defaultWeights, make_response, defaultAncillary) {
-  f <- function(N = 10000, link = defaultLink, weights = defaultWeights,
-                  unrelated = 0, ancillary = defaultAncillary) {
+  force(validLinks)
+  force(defaultLink)
+  force(defaultWeights)
+  force(make_response)
+  force(defaultAncillary)
+
+  # ancillary is only meaningful for some glm famalies
+  # For poisson and binomial it is not needed from a math perspective
+  # Code still accepts the parameter and just does nothing with it.
+  # Want to hide the argument from user in this case.
+  # So setting a dummy value and deleting argument from f.
+  if (is.null(defaultAncillary)) {
+    ancillary <- 1
+  }
+
+  f <- function(N = 10000, link, weights, unrelated = 0, ancillary) {
 
     ####################
     # Check inputs
@@ -209,4 +223,11 @@ make_simulating_function <- function(validLinks, defaultLink, defaultWeights, ma
 
     return(data)
   }
+
+  # Set default values
+  formals(f)$link <- defaultLink
+  formals(f)$weights <- defaultWeights
+  formals(f)$ancillary <- defaultAncillary
+
+  return(f)
 }

--- a/R/simulating_functions.R
+++ b/R/simulating_functions.R
@@ -44,7 +44,7 @@
 #' library(GlmSimulatoR)
 #' library(ggplot2)
 #' library(MASS)
-#'
+#' 
 #' # Do glm and lm estimate the same weights? Yes
 #' set.seed(1)
 #' simdata <- simulate_gaussian()
@@ -53,16 +53,16 @@
 #' summary(linearModel)
 #' summary(glmModel)
 #' rm(linearModel, glmModel, simdata)
-#'
+#' 
 #' # If the effects are multiplicative instead of additive,
 #' # will my response variable still be normal? Yes
 #' set.seed(1)
 #' simdata <- simulate_gaussian(N = 1000, link = "log", weights = c(.1, .2))
-#'
+#' 
 #' ggplot(simdata, aes(x = Y)) +
 #'   geom_histogram(bins = 30)
 #' rm(simdata)
-#'
+#' 
 #' # Is AIC lower for the correct link? For ten thousand data points, depends on seed!
 #' set.seed(1)
 #' simdata <- simulate_gaussian(N = 10000, link = "inverse", weights = 1)
@@ -71,23 +71,23 @@
 #' summary(glmCorrectLink)$aic
 #' summary(glmWrongLink)$aic
 #' rm(simdata, glmCorrectLink, glmWrongLink)
-#'
-#'
+#' 
+#' 
 #' # Does a stepwise search find the correct model for logistic regression? Yes
 #' # 3 related variables. 3 unrelated variables.
 #' set.seed(1)
 #' simdata <- simulate_binomial(N = 10000, link = "logit", weights = c(.3, .4, .5), unrelated = 3)
-#'
+#' 
 #' scopeArg <- list(
 #'   lower = Y ~ 1,
 #'   upper = Y ~ X1 + X2 + X3 + Unrelated1 + Unrelated2 + Unrelated3
 #' )
-#'
+#' 
 #' startingModel <- glm(Y ~ 1, data = simdata, family = binomial(link = "logit"))
 #' glmModel <- stepAIC(startingModel, scopeArg)
 #' summary(glmModel)
 #' rm(simdata, scopeArg, startingModel, glmModel)
-#'
+#' 
 #' # When the resposne is a gamma distribution, what does a scatter plot between X and Y look like?
 #' set.seed(1)
 #' simdata <- simulate_gamma(weights = 1)
@@ -140,7 +140,7 @@ simulate_inverse_gaussian <- make_simulating_function(
   defaultLink = "1/mu^2",
   defaultWeights = 1:3,
   make_response = GlmSimulatoR:::create_inverse_gaussian,
-  defaultAncillary = 1 / 3
+  defaultAncillary = .3333
 )
 
 #' @rdname simulate_gaussian

--- a/man/simulate_gaussian.Rd
+++ b/man/simulate_gaussian.Rd
@@ -10,33 +10,26 @@
 \alias{simulate_tweedie}
 \title{Create ideal data for a generalized linear model.}
 \usage{
-simulate_gaussian(N = 10000, link = defaultLink,
-  weights = defaultWeights, unrelated = 0,
-  ancillary = defaultAncillary)
+simulate_gaussian(N = 10000, link = "identity", weights = 1:3,
+  unrelated = 0, ancillary = 1)
 
-simulate_binomial(N = 10000, link = defaultLink,
-  weights = defaultWeights, unrelated = 0,
-  ancillary = defaultAncillary)
+simulate_binomial(N = 10000, link = "logit", weights = c(0.1, 0.2),
+  unrelated = 0)
 
-simulate_gamma(N = 10000, link = defaultLink,
-  weights = defaultWeights, unrelated = 0,
-  ancillary = defaultAncillary)
+simulate_gamma(N = 10000, link = "inverse", weights = 1:3,
+  unrelated = 0, ancillary = 0.05)
 
-simulate_poisson(N = 10000, link = defaultLink,
-  weights = defaultWeights, unrelated = 0,
-  ancillary = defaultAncillary)
+simulate_poisson(N = 10000, link = "log", weights = c(0.5, 1),
+  unrelated = 0)
 
-simulate_inverse_gaussian(N = 10000, link = defaultLink,
-  weights = defaultWeights, unrelated = 0,
-  ancillary = defaultAncillary)
+simulate_inverse_gaussian(N = 10000, link = "1/mu^2", weights = 1:3,
+  unrelated = 0, ancillary = 0.3333)
 
-simulate_negative_binomial(N = 10000, link = defaultLink,
-  weights = defaultWeights, unrelated = 0,
-  ancillary = defaultAncillary)
+simulate_negative_binomial(N = 10000, link = "log", weights = c(0.5,
+  1), unrelated = 0, ancillary = 1)
 
-simulate_tweedie(N = 10000, link = defaultLink,
-  weights = defaultWeights, unrelated = 0,
-  ancillary = defaultAncillary)
+simulate_tweedie(N = 10000, link = "log", weights = 0.02,
+  unrelated = 0, ancillary = 1.15)
 }
 \arguments{
 \item{N}{Sample size. (Default: 10000)}

--- a/tests/testthat/test_simulate_binomial.R
+++ b/tests/testthat/test_simulate_binomial.R
@@ -54,10 +54,6 @@ test_that("All links execute", {
   expect_true(all(class(simulate_binomial(link = "identity", weights = .1)) == c("tbl_df", "tbl", "data.frame")))
 })
 
-test_that("Ancillary parameter function works if ancillary is provided", {
-  expect_true(simulate_binomial(ancillary = 10) %>% nrow() > 0)
-})
-
 ###############################################
 # Input checking
 ###############################################
@@ -68,6 +64,4 @@ test_that("Confirm input checing works.", {
   expect_error(simulate_binomial(weights = c()), NULL)
   expect_error(simulate_binomial(unrelated = -1), NULL)
   expect_error(simulate_binomial(unrelated = c(10, 20)), NULL)
-  expect_error(simulate_binomial(ancillary = -1), NULL)
-  expect_error(simulate_binomial(ancillary = c(10, 20)), NULL)
 })

--- a/tests/testthat/test_simulate_poisson.R
+++ b/tests/testthat/test_simulate_poisson.R
@@ -48,10 +48,6 @@ test_that("All links execute", {
   expect_true(all(class(simulate_poisson(link = "sqrt")) == c("tbl_df", "tbl", "data.frame")))
 })
 
-test_that("Ancillary parameter function works if ancillary is provided", {
-  expect_true(simulate_poisson(ancillary = 10) %>% nrow() > 0)
-})
-
 ###############################################
 # Input checking
 ###############################################
@@ -62,6 +58,4 @@ test_that("Confirm input checing works.", {
   expect_error(simulate_poisson(weights = c()), NULL)
   expect_error(simulate_poisson(unrelated = -1), NULL)
   expect_error(simulate_poisson(unrelated = c(10, 20)), NULL)
-  expect_error(simulate_poisson(ancillary = -1), NULL)
-  expect_error(simulate_poisson(ancillary = c(10, 20)), NULL)
 })


### PR DESCRIPTION
Changing make_simulating_function to programmatically set default values at compile time, not execution. 

Changes are
     Forcing evaluation of make_simulating_function  arguments
     Editing formal arguments of manufacturer function.
